### PR TITLE
Fixing kubeval reg name

### DIFF
--- a/deployment/addons/vela-core/templates/addon_registry.yaml
+++ b/deployment/addons/vela-core/templates/addon_registry.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   registries: '{
-  "KubeVela":{
-    "name": "KubeVela",
+  "kubevela":{
+    "name": "kubevela",
     "helm": {
       "url": "https://kubevela.github.io/catalog/official"
     }


### PR DESCRIPTION
With current registry values seeing below error:
![image](https://github.com/shapirov103/appmod-blueprints/assets/118366916/28281c90-46f0-4679-b9bb-e11c9386dab3)


```
Error: release name "Kubevela": invalid release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53
```

This PR fixes the name to match the required regex