### PR TITLE
Fixing gradle config for latest versions

### DIFF
--- a/applications/java/ci/buildspec-java.yaml
+++ b/applications/java/ci/buildspec-java.yaml
@@ -18,10 +18,10 @@ phases:
       - pip3 install git-remote-codecommit
       - echo Logging in to CodeCommit
       - mkdir /opt/gradle
-      - wget -c https://services.gradle.org/distributions/gradle-8.4-bin.zip
-      - unzip -d /opt/gradle gradle-8.4-bin.zip
+      - wget -cq https://services.gradle.org/distributions/gradle-8.4-bin.zip
+      - unzip -q -d /opt/gradle gradle-8.4-bin.zip
       - export PATH=$PATH:/opt/gradle/gradle-8.4/bin
-      - yum -y install docker java-1.8.0
+      - yum -y -q install docker java-1.8.0
       - rm -rf gradle-8.4-bin.zip
       - git clone codecommit://appmod-workshop
       - echo Logging in to Amazon ECR...

--- a/applications/java/src/build.gradle
+++ b/applications/java/src/build.gradle
@@ -2,6 +2,5 @@ apply plugin: 'java'
 apply plugin: 'war'
 
 war {
-    baseName = 'java-app'
-    archiveName 'java-app.war'
+    archivesBaseName = 'java-app'
 }


### PR DESCRIPTION
With latest gradle version(build spec installs gradle-8.4), at the build time seeing:

```


[Container] 2023/10/24 17:27:00.219608 Running command gradle clean build
--
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
FAILURE: Build failed with an exception.

Build file '/codebuild/output/src1774901143/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/appmod-workshop/appmod-workshop/applications/java/src/build.gradle' line: 6

* What went wrong:
A problem occurred evaluating root project 'src'.
> Could not find method archiveName() for arguments [java-app.war] on task ':war' of type org.gradle.api.tasks.bundling.War.

```

So this PR fixes with the relevant attribute name. This PR also adds quiet/q flag to some of the noisy install commands. 