### PR TITLE
Update cleanup-hybrid-cluster.sh

### DIFF
--- a/workshop/cleanup-hybrid-cluster.sh
+++ b/workshop/cleanup-hybrid-cluster.sh
@@ -1,3 +1,3 @@
 cd ~/environment/appmod-workshop
 npm i
-cdk destroy hybrid-cluster
+cdk destroy hybrid-cluster --require-approval never

--- a/workshop/cleanup-hybrid-cluster.sh
+++ b/workshop/cleanup-hybrid-cluster.sh
@@ -1,3 +1,3 @@
 cd ~/environment/appmod-workshop
 npm i
-cdk destroy hybrid-cluster --require-approval never
+cdk destroy hybrid-cluster --force


### PR DESCRIPTION
Adds flag ` --require-approval never` so users are not prompted for cluster destroy script.